### PR TITLE
ACF 2016 compatibility: switched contains() for arrayContains()

### DIFF
--- a/models/InstanceService.cfc
+++ b/models/InstanceService.cfc
@@ -49,7 +49,7 @@ component{
 			//targetID = targetID.listLast( '.' );
 			// Add information about this injection to our global setting
 			instanceMap[ arguments.targetID ] = instanceMap[ arguments.targetID ] ?: [];
-			if( !instanceMap[ arguments.targetID ].contains( thisInstanceName ) ) {
+			if( !arrayContains( instanceMap[ arguments.targetID ], thisInstanceName ) ) {
 				instanceMap[ arguments.targetID ].append( thisInstanceName );	
 			}
 			


### PR DESCRIPTION
ACF 2016 doesn't support contains() unfortunately so switching this to arrayContains() should make it work on both Lucee and ACF.